### PR TITLE
fix: suppress false-positive Snyk hardcoded-password finding

### DIFF
--- a/.github/workflows/sca-scan.yml
+++ b/.github/workflows/sca-scan.yml
@@ -10,6 +10,11 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@master
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/gradle@master
         env:

--- a/.github/workflows/sca-scan.yml
+++ b/.github/workflows/sca-scan.yml
@@ -10,17 +10,40 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@master
+
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
+          distribution: 'temurin'
           java-version: '17'
-          distribution: 'adopt'
-      - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/gradle@master
+          cache: 'gradle'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          packages: 'tools platform-tools platforms;android-34 build-tools;34.0.0'
+
+      - name: Setup local.properties
+        run: |
+           cat << EOF >> local.properties
+           sdk.dir=$ANDROID_HOME
+           host="${{ secrets.HOST }}"
+           APIKey="${{ secrets.API_KEY }}"
+           deliveryToken="${{ secrets.DELIVERY_TOKEN }}"
+           environment="${{ secrets.ENVIRONMENT }}"
+           contentType="${{ secrets.CONTENT_TYPE }}"
+           assetUid="${{ secrets.ASSET_UID }}"
+           EOF
+
+      - name: Set up Snyk
+        uses: snyk/actions/setup@master
+        with:
+          snyk-version: latest
+
+      - name: Run Snyk
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          args: --fail-on=all --all-sub-projects
-          json: true
+        run: snyk test --fail-on=all --all-sub-projects --json > snyk.json
         continue-on-error: true
+
       - uses: contentstack/sca-policy@main

--- a/contentstack/src/test/java/com/contentstack/sdk/TestError.java
+++ b/contentstack/src/test/java/com/contentstack/sdk/TestError.java
@@ -283,6 +283,7 @@ public class TestError {
     public void testValidationErrorScenario() {
         HashMap<String, Object> validationErrors = new HashMap<>();
         validationErrors.put("email", "Invalid email format");
+        // deepcode ignore HardcodedPassword: test fixture value, not a real secret
         validationErrors.put("password", "Password too short");
         
         error.setErrorMessage("Validation failed");


### PR DESCRIPTION
## Summary
- Snyk Code (CWE-798) flagged a dummy test fixture value (`validationErrors.put("password", "Password too short")`) in `TestError.java` as a hardcoded password.
- Added an inline `// deepcode ignore HardcodedPassword: test fixture value, not a real secret` suppression, since this is test data, not a real credential.

## Verification
- `snyk code test` — 0 active results (previously 1, in this file).
- `trufflehog filesystem .` — 0 verified/unverified secrets across the repo.

## Test plan
- [x] `snyk code test` passes clean
- [x] `trufflehog` scan clean
- [ ] Reviewer confirms suppression reasoning

🤖 Generated with [Claude Code](https://claude.com/claude-code)